### PR TITLE
Throw on missing active file when saving to same folder

### DIFF
--- a/statblocks/statblocks.ts
+++ b/statblocks/statblocks.ts
@@ -139,7 +139,11 @@ export async function saveStatblockToFile(plugin: StatblockSidekick, content: st
     let folderPath: string;
     switch (settings.saveMode) {
         case 'sameFolder':
-        folderPath = this.app.workspace.getActiveFile().parent.path;
+        const activeFile = plugin.app.workspace.getActiveFile();
+        if (!activeFile?.parent) {
+            throw new Error('Expected an active file when saving to the same folder.');
+        }
+        folderPath = activeFile.parent.path;
         break;
         case 'defaultFolder':
         folderPath = normalizePath(settings.saveFolder);


### PR DESCRIPTION
## Summary
- align same-folder save logic with expectation that an active file is present
- throw an explicit error if no active file parent is available when determining the folder path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927723af7ec8330b8580b4a1cbe796e)